### PR TITLE
Support building tests by clang

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /config.log
 /config.status
 /build
+/isa/musl

--- a/Makefile.in
+++ b/Makefile.in
@@ -28,6 +28,10 @@ isa:
 	mkdir -p isa
 	$(MAKE) -C isa -f $(isa_src_dir)/Makefile src_dir=$(isa_src_dir) XLEN=$(XLEN) $(RISCV_PREFIX_VAR)
 
+isa-clang:
+	mkdir -p isa
+	$(MAKE) -C isa -f $(isa_src_dir)/Makefile.clang src_dir=$(isa_src_dir) XLEN=$(XLEN) $(RISCV_PREFIX_VAR)
+
 debug-check:
 	mkdir -p debug
 	$(MAKE) -C debug -f $(debug_src_dir)/Makefile src_dir=$(debug_src_dir) XLEN=$(XLEN)
@@ -42,4 +46,3 @@ clean:
 	[ ! -d debug ]      || $(MAKE) -C debug -f $(debug_src_dir)/Makefile src_dir=$(debug_src_dir) clean
 
 .PHONY: benchmarks isa clean
-

--- a/isa/Makefile.clang
+++ b/isa/Makefile.clang
@@ -1,0 +1,121 @@
+#=======================================================================
+# Makefile for riscv-tests/isa
+#-----------------------------------------------------------------------
+
+XLEN ?= 64
+
+src_dir := .
+
+ifeq ($(XLEN),64)
+include $(src_dir)/rv64ui/Makefrag
+include $(src_dir)/rv64uc/Makefrag
+include $(src_dir)/rv64um/Makefrag
+include $(src_dir)/rv64ua/Makefrag
+endif
+include $(src_dir)/rv32ui/Makefrag
+include $(src_dir)/rv32uc/Makefrag
+include $(src_dir)/rv32um/Makefrag
+include $(src_dir)/rv32ua/Makefrag
+
+
+default: musl all
+
+musl:
+	git clone https://github.com/xxuejie/musl
+	cd musl && ./ckb/build.sh && cd ..
+
+#--------------------------------------------------------------------
+# Build rules
+#--------------------------------------------------------------------
+
+CLANG := $(shell ../scripts/find_clang)
+OBJDUMP := $(subst clang,llvm-objdump,$(CLANG))
+RISCV_GCC ?= $(CLANG) --target=riscv64-unknown-elf
+RISCV_GCC_OPTS ?= -static -mcmodel=medany -fvisibility=hidden -nostdlib -isystem musl/release/include -Lmusl/release/lib
+RISCV_OBJDUMP ?= $(OBJDUMP) --disassemble-all --disassemble-zeroes --section=.text --section=.text.startup --section=.text.init --section=.data
+RISCV_SIM ?= spike
+
+vpath %.S $(src_dir)
+
+#------------------------------------------------------------
+# Build assembly tests
+
+%.dump: %
+	$(RISCV_OBJDUMP) $< > $@
+
+%.out: %
+	$(RISCV_SIM) --isa=rv64gc_zfh_zicboz_svnapot --misaligned $< 2> $@
+
+%.out32: %
+	$(RISCV_SIM) --isa=rv32gc_zfh_zicboz_svnapot --misaligned $< 2> $@
+
+define compile_template
+
+$$($(1)_p_tests): $(1)-p-%: $(1)/%.S
+	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) -I$(src_dir)/../env/p -I$(src_dir)/macros/scalar -T$(src_dir)/../env/p/link.ld $$< -o $$@
+$(1)_tests += $$($(1)_p_tests)
+
+$$($(1)_v_tests): $(1)-v-%: $(1)/%.S
+	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) -DENTROPY=0x$$(shell echo \$$@ | md5sum | cut -c 1-7) -std=gnu99 -O2 -I$(src_dir)/../env/v -I$(src_dir)/macros/scalar -T$(src_dir)/../env/v/link.ld $(src_dir)/../env/v/entry.S $(src_dir)/../env/v/*.c $$< -o $$@
+$(1)_tests += $$($(1)_v_tests)
+
+$$($(1)_u_tests): $(1)-u-%: $(1)/%.S
+	$$(RISCV_GCC) $(2) $$(RISCV_GCC_OPTS) -DENTROPY=0x$$(shell echo \$$@ | md5sum | cut -c 1-7) -std=gnu99 -O2 -I$(src_dir)/../env/u -I$(src_dir)/macros/scalar -T$(src_dir)/../env/u/link.ld $(src_dir)/../env/u/entry.S $(src_dir)/../env/u/*.c $$< -o $$@
+$(1)_tests += $$($(1)_u_tests)
+
+$(1)_tests_dump = $$(addsuffix .dump, $$($(1)_tests))
+
+$(1): $$($(1)_tests_dump)
+
+.PHONY: $(1)
+
+COMPILER_SUPPORTS_$(1) := $$(shell $$(RISCV_GCC) $(2) -c -x c /dev/null -o /dev/null 2> /dev/null; echo $$$$?)
+
+ifeq ($$(COMPILER_SUPPORTS_$(1)),0)
+tests += $$($(1)_tests)
+endif
+
+endef
+
+$(eval $(call compile_template,rv32ui,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32uc,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32um,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32ua,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32uf,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32ud,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32uzfh,-march=rv32g_zfh -mabi=ilp32))
+$(eval $(call compile_template,rv32si,-march=rv32g -mabi=ilp32))
+$(eval $(call compile_template,rv32mi,-march=rv32g -mabi=ilp32))
+ifeq ($(XLEN),64)
+$(eval $(call compile_template,rv64ui,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64uc,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64um,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64ua,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64uf,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64ud,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64uzfh,-march=rv64g_zfh -mabi=lp64))
+$(eval $(call compile_template,rv64mzicbo,-march=rv64g_zicboz -mabi=lp64))
+$(eval $(call compile_template,rv64si,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64ssvnapot,-march=rv64g -mabi=lp64))
+$(eval $(call compile_template,rv64mi,-march=rv64g -mabi=lp64))
+endif
+
+tests_dump = $(addsuffix .dump, $(tests))
+tests_hex = $(addsuffix .hex, $(tests))
+tests_out = $(addsuffix .out, $(filter rv64%,$(tests)))
+tests32_out = $(addsuffix .out32, $(filter rv32%,$(tests)))
+
+run: $(tests_out) $(tests32_out)
+
+junk += $(tests) $(tests_dump) $(tests_hex) $(tests_out) $(tests32_out)
+
+#------------------------------------------------------------
+# Default
+
+all: $(tests_dump)
+
+#------------------------------------------------------------
+# Clean up
+
+clean:
+	rm -rf $(junk)

--- a/isa/Makefile.clang
+++ b/isa/Makefile.clang
@@ -22,7 +22,7 @@ default: musl all
 
 musl:
 	git clone https://github.com/xxuejie/musl
-	cd musl && ./ckb/build.sh && cd ..
+	cd musl && git checkout 01ff4b57cb8af5e8c5df1239cc1a5a064452b70d && ./ckb/build.sh && cd ..
 
 #--------------------------------------------------------------------
 # Build rules

--- a/scripts/find_clang
+++ b/scripts/find_clang
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# An utility script used to find a binary of clang 16+
+
+if [[ -n "${CLANG}" ]]; then
+  echo "${CLANG}"
+  exit 0
+fi
+
+# To cope with packaging messes from different distros, we would search
+# for a different binary other than clang, then convert it back to clang
+# at the end.
+SEARCH_TARGET="${SEARCH_TARGET:-llvm-strip}"
+
+CANDIDATES=("${SEARCH_TARGET}" "${SEARCH_TARGET}-19" "${SEARCH_TARGET}-18" "${SEARCH_TARGET}-17" "${SEARCH_TARGET}-16")
+
+BREW_PREFIX=$(brew --prefix 2> /dev/null)
+if [[ -n "${BREW_PREFIX}" ]]; then
+  CANDIDATES+=(
+    "${BREW_PREFIX}/opt/llvm/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@19/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@18/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@17/bin/${SEARCH_TARGET}"
+    "${BREW_PREFIX}/opt/llvm@16/bin/${SEARCH_TARGET}"
+  )
+fi
+
+for candidate in ${CANDIDATES[@]}; do
+  OUTPUT=$($candidate --version 2> /dev/null | grep 'version [0-9]' | head -n 1 | cut -d'.' -f 1 | grep -o '[0-9][0-9]*')
+
+  if [[ $((OUTPUT)) -ge 16 ]]; then
+    echo "${candidate/${SEARCH_TARGET}/clang}"
+    exit 0
+  fi
+done
+
+>&2 echo "Cannot find clang of version 16+!"
+exit 1


### PR DESCRIPTION
Added a new Makefile script to compile the test suite using clang.

```sh
$ autoconf
$ ./configure
$ make isa-clang
```

> Note that Makefile.clang is a copy of the original Makefile with only the necessary modifications.
